### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,5 +1,8 @@
 name: Check branch fast-forward-ness
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Spring-Easy-Tools/spring-module-example/security/code-scanning/14](https://github.com/Spring-Easy-Tools/spring-module-example/security/code-scanning/14)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only checks branch fast-forward status and does not modify repository contents, it likely only requires read access to the repository contents. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
